### PR TITLE
sci-server: hack in service cache-warming

### DIFF
--- a/src/sci-server/hackityhack.go
+++ b/src/sci-server/hackityhack.go
@@ -1,0 +1,28 @@
+// hackityhack.go (not to be confused with donttalkback.go) is absolutely not a
+// terrible hack just to try and reduce the slowness on the first hit to the
+// lambda-like person lookup service.
+
+package sciserver
+
+import (
+	"time"
+
+	"github.com/uoregon-libraries/gopkg/logger"
+	"github.com/uoregon-libraries/student-course-integrator/src/service"
+)
+
+var lastWarmed time.Time
+
+func warmCache() {
+	if time.Since(lastWarmed) < time.Hour {
+		return
+	}
+	go hackityhackWarmIt()
+}
+
+func hackityhackWarmIt() {
+	logger.Debugf("Warming the person lookup cache")
+	lastWarmed = time.Now()
+	service.DuckID("nobody").Call()
+	logger.Debugf("Warmed")
+}

--- a/src/sci-server/handler.go
+++ b/src/sci-server/handler.go
@@ -35,6 +35,7 @@ func hHome() *homeHandler {
 
 // ServeHTTP implements http.Handler for homeHandler
 func (h *homeHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	warmCache()
 	var r = respond(w, req, h)
 	if req.Method == "POST" {
 		r.processSubmission()


### PR DESCRIPTION
This will fire off one extra user lookup at most every hour, and only
when an authorized user hits the homepage.  Hopefully this speeds up the
first lookup for most people.  It obviously won't do us any good if
users load the site, get distracted, and fill the form out hours later.