### PR TITLE
person: don't return errors when service 404s

### DIFF
--- a/src/person/person.go
+++ b/src/person/person.go
@@ -41,6 +41,9 @@ func FindByDuckID(duckid string) (*Person, error) {
 			return nil, fmt.Errorf("unable to look up Banner ID for duckid %s: %s", p.DuckID, err)
 		}
 		var r = s.Response
+		if r.StatusCode == 404 {
+			return nil, nil
+		}
 		if r.StatusCode != 200 {
 			return nil, fmt.Errorf("service: status %d looking up %s: %s", r.StatusCode, p.DuckID, r.Message)
 		}


### PR DESCRIPTION
A 404 from the duckid-to-banner service just means the user doesn't
exist; it's not really an error