### PR TITLE
Feature/refactor handler

### DIFF
--- a/src/sci-server/handler.go
+++ b/src/sci-server/handler.go
@@ -44,7 +44,7 @@ func (r *responder) audit(f *form, a audit.Action) {
 	data["crn"] = f.CRN
 	data["duckid"] = f.DuckID
 	data["confirm"] = f.Confirm
-	data["role"] = "GE"
+	data["role"] = f.Role
 	if len(f.errors) > 0 {
 		data["errors"] = f.errorString()
 	}


### PR DESCRIPTION
Closes #31.  Refactor includes a bit more than what's in that ticket, but it seemed necessary to break things up a bit more than I originally was planning.  Even so, all refactoring is confined to `handler.go`.