### PR TITLE
Enforce grader checkbox

### DIFF
--- a/static/js/enforce_confirm.js
+++ b/static/js/enforce_confirm.js
@@ -1,0 +1,14 @@
+document.addEventListener("DOMContentLoaded", function() {
+  // Don't validate when clicking the "go back" button
+  var goBack = document.getElementById("submit-go-back");
+  goBack.addEventListener("click", function() {
+    document.getElementById("association-form-confirm").setAttribute("novalidate", "novalidate");
+  });
+
+  var agree = document.getElementById("graderReqMet");
+  agree.setCustomValidity("You must agree to the terms for assigning a Grader to a course");
+  agree.addEventListener("change", function() {
+    this.setCustomValidity(this.validity.valueMissing ? myCheckboxMsg : "");
+  }, false);
+
+}, false);

--- a/templates/confirm_duckid.go.html
+++ b/templates/confirm_duckid.go.html
@@ -16,17 +16,21 @@
   </p>
 </div>
 
-<form id="association-form" method="POST" action="{{FullPath ""}}">
+<form id="association-form-confirm" method="POST" action="{{FullPath ""}}">
   <input type="hidden" name="duckid" id="duckid" value="{{.Form.DuckID}}"/>
   <input type="hidden" name="crn" id="crn" value="{{.Form.CRN}}" />
   <input type="hidden" name="role" id="role" value="{{.Form.Role}}" />
   {{if .Form.IsGrader }}
     <p>
     <label for="graderReqMet">I agree this student can be a grader:</label>
-    <input type="checkbox" name="graderReqMet" id="graderReqMet" value="1">
+    <input type="checkbox" name="graderReqMet" id="graderReqMet" required value="1">
     </p>
   {{end}}
-  <button class="btn btn-success" type="submit" name="confirm" value="1" class="prevent-double-click">Confirm</button>
-  <button class="btn btn-secondary" type="submit" name="confirm" value="0" class="prevent-double-click">Go Back</button>
+  <button class="btn btn-success" type="submit" name="confirm" value="1" id="submit-confirm" class="prevent-double-click">Confirm</button>
+  <button class="btn btn-secondary" type="submit" name="confirm" value="0" id="submit-go-back" class="prevent-double-click">Go Back</button>
 </form>
+{{end}}
+
+{{block "extrajs" .}}
+{{IncludeJS "enforce_confirm"}}
 {{end}}


### PR DESCRIPTION
Uses some basic scripting to enforce that on submission of the
confirmation form, the checkbox has been clicked.  The backend is
unchanged - we don't allow a hacked form through.