### PR TITLE
Fix JS typo

### DIFF
--- a/static/js/enforce_confirm.js
+++ b/static/js/enforce_confirm.js
@@ -6,9 +6,10 @@ document.addEventListener("DOMContentLoaded", function() {
   });
 
   var agree = document.getElementById("graderReqMet");
-  agree.setCustomValidity("You must agree to the terms for assigning a Grader to a course");
+  var msg = "You must agree to the terms for assigning a Grader to a course";
+  agree.setCustomValidity(msg);
   agree.addEventListener("change", function() {
-    this.setCustomValidity(this.validity.valueMissing ? myCheckboxMsg : "");
+    this.setCustomValidity(this.validity.valueMissing ? msg : "");
   }, false);
 
 }, false);


### PR DESCRIPTION
Fixes lost validation message when clicking the checkbox, then clearing
it again, then submitting